### PR TITLE
Fix inference route

### DIFF
--- a/gitops/instance/llm-d/gateway.yaml
+++ b/gitops/instance/llm-d/gateway.yaml
@@ -11,7 +11,7 @@ metadata:
   name: openshift-ai-inference
   namespace: openshift-ingress
 spec:
-  gatewayClassName: istio
+  gatewayClassName: openshift-default
   listeners:
     - name: http
       port: 80


### PR DESCRIPTION
The gateway object does not reference a real gateway class.  No route will be available for the inference. This fixes the reference following OCP instructions: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/ingress_and_load_balancing/configuring-ingress-cluster-traffic#nw-ingress-gateway-api-enable_ingress-gateway-api